### PR TITLE
handled upgrade scenario

### DIFF
--- a/ios/CodePush/CodePush/Common/Core/CodePushBaseCore.swift
+++ b/ios/CodePush/CodePush/Common/Core/CodePushBaseCore.swift
@@ -239,9 +239,12 @@ class CodePushBaseCore {
         configuration.deploymentKey = !deploymentKey.isEmpty ? deploymentKey : configuration.deploymentKey
         do {
             let localPackage = try getUpdateMetadata(inUpdateState: .latest)
-            let queryPackage = localPackage != nil ? localPackage :
-                CodePushLocalPackage.createEmptyPackageForUpdateQuery(withVersion: configuration.appVersion)
-
+            var queryPackage = localPackage
+            if !self.appVersion.isEmpty {
+                queryPackage = CodePushLocalPackage.createEmptyPackageForUpdateQuery(withVersion: self.appVersion)
+            } else if queryPackage == nil{
+                queryPackage = CodePushLocalPackage.createEmptyPackageForUpdateQuery(withVersion: configuration.appVersion)
+            }
             CodePushAcquisitionManager(utilities.utils, utilities.fileUtils)
                 .queryUpdate(withConfig: configuration, withPackage: queryPackage!,
                              callback: { result in


### PR DESCRIPTION
Added handling to use the appVersion if provided explicitly.If not provided, use the version of the locla installed package else get the version from nativeConfig.